### PR TITLE
Use UnixNano() as seed for random

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -51,7 +51,7 @@ func (c *Config) init() {
 		c.output = os.Stdout
 		c.errOutput = os.Stderr
 		c.origin = 1
-		c.source = rand.NewSource(time.Now().Unix())
+		c.source = rand.NewSource(time.Now().UnixNano())
 		c.random = rand.New(c.source)
 		c.maxBits = 1e6
 		c.maxDigits = 1e4


### PR DESCRIPTION
Minor patch to ensure different random numbers between runs of `ivy` (e.g. in a script).