### PR TITLE
Remove unnecessary int conversions on scanner.pos since it is already an int

### DIFF
--- a/scan/scan.go
+++ b/scan/scan.go
@@ -109,10 +109,10 @@ func (l *Scanner) loadLine() {
 
 // next returns the next rune in the input.
 func (l *Scanner) next() rune {
-	if !l.done && int(l.pos) == len(l.input) {
+	if !l.done && l.pos == len(l.input) {
 		l.loadLine()
 	}
-	if len(l.input) == int(l.pos) {
+	if len(l.input) == l.pos {
 		l.width = 0
 		return eof
 	}


### PR DESCRIPTION
I made these changes against the dev branch. Build successful and all tests passing.

`randall@dev:~/src/robpike.io/ivy$ go build`
`randall@dev:~/src/robpike.io/ivy$ go test ./...`
`ok      robpike.io/ivy  1.173s`
`?       robpike.io/ivy/config   [no test files]`
`?       robpike.io/ivy/exec     [no test files]`
`ok      robpike.io/ivy/mobile   1.108s`
`?       robpike.io/ivy/parse    [no test files]`
`?       robpike.io/ivy/parse/exec       [no test files]`
`?       robpike.io/ivy/run      [no test files]`
`?       robpike.io/ivy/scan     [no test files]`
`?       robpike.io/ivy/talks    [no test files]`
`?       robpike.io/ivy/value    [no test files]`
