### PR TITLE
remove unnecessary os.Exit call in flag.Usage

### DIFF
--- a/ivy.go
+++ b/ivy.go
@@ -113,5 +113,4 @@ func usage() {
 	fmt.Fprintf(os.Stderr, "usage: ivy [options] [file ...]\n")
 	fmt.Fprintf(os.Stderr, "Flags:\n")
 	flag.PrintDefaults()
-	os.Exit(2)
 }


### PR DESCRIPTION
The `flag` package already calls `os.Exit(2)` inside `flag.Parse` when the parse fails. After this change, `usage` becomes simpler and the behavior of ivy remains unchanged.

See https://github.com/mdempsky/unconvert/commit/3b9aa41c71a855a5f5fee96dc751979ce6e8cbbe, https://github.com/campoy/embedmd/pull/12, and https://upspin-review.googlesource.com/c/9642/ for precedent.

Reference: https://dmitri.shuralyov.com/idiomatic-go#don-t-os-exit-2-inside-flag-usage.

---

I've made this PR into the `dev` branch, as per your contribution policy. `go test` succeeds:

```
$ go test -race robpike.io/ivy/...
ok  	robpike.io/ivy	6.568s
?   	robpike.io/ivy/config	[no test files]
?   	robpike.io/ivy/exec	[no test files]
ok  	robpike.io/ivy/mobile	1.342s
?   	robpike.io/ivy/parse	[no test files]
?   	robpike.io/ivy/parse/exec	[no test files]
?   	robpike.io/ivy/run	[no test files]
?   	robpike.io/ivy/scan	[no test files]
?   	robpike.io/ivy/talks	[no test files]
?   	robpike.io/ivy/value	[no test files]
```

And ivy behaves the same when there's an error during flag parsing:

```
$ ivy -badflag
flag provided but not defined: -badflag
usage: ivy [options] [file ...]
Flags:
  -debug names
    	comma-separated names of debug settings to enable
  -e	execute arguments as a single expression
  -format fmt
    	use fmt as format for printing numbers; empty sets default format
  -g	shorthand for -format="%.12g"
  -maxbits uint
    	maximum size of an integer, in bits; 0 means no limit (default 1000000000)
  -maxdigits digits
    	above this many digits, integers print as floating point; 0 disables (default 10000)
  -origin n
    	set index origin to n (must be 0 or 1) (default 1)
  -prompt prompt
    	command prompt
ivy $ echo $?
2
```