### PR TITLE
README: update formatting and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ivy has a custom domain. Do not install using github directly. Instead, run:
 
 	go get robpike.io/ivy
 
-Documentation at http://godoc.org/robpike.io/ivy.
+Documentation at https://godoc.org/robpike.io/ivy.
 
 Try the demo:
 
@@ -17,8 +17,8 @@ Try the demo:
 Prototype apps for iPhone, iPad, and Android are available in the App store and Google Play store.
 To find them, search for "ivy bignum calculator".
 
-Slides for a talk at: http://go-talks.appspot.com/github.com/robpike/ivy/talks/ivy.slide  
-Video for the talk at: http://www.youtube.com/watch?v=PXoG0WX0r_E  
+Slides for a talk at: https://talks.godoc.org/github.com/robpike/ivy/talks/ivy.slide  
+Video for the talk at: https://www.youtube.com/watch?v=PXoG0WX0r_E  
 The talk predates a lot of the features, including floating point, text, and user-defined operators.
 
 To be built, ivy requires Go 1.5.

--- a/README.md
+++ b/README.md
@@ -5,20 +5,22 @@ Ivy is an interpreter for an APL-like language. It is a plaything and a work in
 progress.
 
 Ivy has a custom domain. Do not install using github directly. Instead, run:
+
 	go get robpike.io/ivy
 
 Documentation at http://godoc.org/robpike.io/ivy.
+
 Try the demo:
+
 	cd demo; go run demo.go
 
 Prototype apps for iPhone, iPad, and Android are available in the App store and Google Play store.
 To find them, search for "ivy bignum calculator".
 
-Slides for a talk at: http://go-talks.appspot.com/github.com/robpike/ivy/talks/ivy.slide
-Video for the talk at: http://www.youtube.com/watch?v=PXoG0WX0r_E
+Slides for a talk at: http://go-talks.appspot.com/github.com/robpike/ivy/talks/ivy.slide  
+Video for the talk at: http://www.youtube.com/watch?v=PXoG0WX0r_E  
 The talk predates a lot of the features, including floating point, text, and user-defined operators.
 
 To be built, ivy requires Go 1.5.
-
 
 ![Ivy](ivy.jpg)


### PR DESCRIPTION
This PR is heavily inspired by PR #42 (/cc @BDMorrell @robpike), but takes a slightly different approach to improving the formatting. It tries make it render more like the raw markdown text file looks (I hope that's the original intention, but let me know if not).

It also updates the links to use HTTPS scheme and newer canonical address for https://talks.godoc.org.

Finally, this PR is based on `dev` branch rather than `master`, which I understand is the expected way to contribute, based on what @robpike has said in the past.

If merged, this should close #42.