### PR TITLE
Add a Go import comment

### DIFF
--- a/talks/script.go
+++ b/talks/script.go
@@ -1,4 +1,4 @@
-package main
+package main // import "robpike.io/ivy/talks"
 
 import (
 	"bufio"


### PR DESCRIPTION
This pull request was made with an automated tool.

The suggested change adds an import comment to a file in the package
to ensure that this package is always imported using its canonical
import path. With this comment in place, the go tool guarantees
that the package can be imported only from this path.

For more information, see https://golang.org/s/go14customimport,
in particular the "Proposal" section.
