### PR TITLE
Add Go import comments.

### DIFF
--- a/mobile/help.go
+++ b/mobile/help.go
@@ -1,4 +1,4 @@
-package mobile
+package mobile // import "robpike.io/ivy/mobile"
 
 // GENERATED; DO NOT EDIT
 const help = `<!-- auto-generated from robpike.io/ivy package doc -->

--- a/parse/exec/opdef.go
+++ b/parse/exec/opdef.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package exec
+package exec // import "robpike.io/ivy/parse/exec"
 
 // OpDef is just a record of an op's name and arg count.
 // It is held in execContext.defs to control writing the


### PR DESCRIPTION
This pull request was made with an automated tool.

The suggested change adds an import comment to a file in each package
to ensure that the package is always imported using its canonical
import path. With this comment in place, the go tool guarantees
that the package can be imported only from this path.

For more information, see https://golang.org/s/go14customimport,
in particular the "Proposal" section.
