### PR TITLE
Add a Go import comment.

### DIFF
--- a/mobile/help.go
+++ b/mobile/help.go
@@ -1,4 +1,4 @@
-package mobile
+package mobile // import "robpike.io/ivy/mobile"
 
 // GENERATED; DO NOT EDIT
 const help = `<!-- auto-generated from robpike.io/ivy package doc -->


### PR DESCRIPTION
This pull request was made with an automated tool.

The suggested change adds an import comment to a file in each package
to ensure that the package is always imported using its canonical
import path. With this comment in place, the go tool guarantees
that the package can be imported only from this path.

For more information, see https://golang.org/s/go14customimport,
in particular the "Proposal" section.
