### PR TITLE
ivy: fix buggy interaction between take and comma

### DIFF
--- a/testdata/binary_int.ivy
+++ b/testdata/binary_int.ivy
@@ -542,3 +542,10 @@
 
 1 in 1
 	1
+
+# used to append into x[:2]!
+x = 1 2 3 4 5
+(2 take x), 6 7
+x
+	1 2 6 7
+	1 2 3 4 5

--- a/value/binary.go
+++ b/value/binary.go
@@ -1134,7 +1134,9 @@ func init() {
 			whichType: atLeastVectorType,
 			fn: [numType]binaryFn{
 				vectorType: func(c Context, u, v Value) Value {
-					return append(u.(Vector), v.(Vector)...)
+					uu := u.(Vector)
+					uu = uu[:len(uu):len(uu)]
+					return append(uu, v.(Vector)...)
 				},
 				matrixType: func(c Context, u, v Value) Value {
 					A := u.(*Matrix)
@@ -1178,14 +1180,14 @@ func init() {
 						if -n > len {
 							panic(bad)
 						}
-						i = i[len+n : len]
+						i = i[len+n : len : len]
 					case n == 0:
 						return NewVector(nil)
 					case n > 0:
 						if n > len {
 							panic(bad)
 						}
-						i = i[0:n]
+						i = i[0:n:n]
 					}
 					return i
 				},


### PR DESCRIPTION
	x = 1 2 3 4 5
	(2 take x), 6 7
	x

Because (2 take x) slices x and comma appends,
this was overwriting x to be 1 2 6 7 5.

Fix twice, by making both take and comma trim capacity.