### PR TITLE
ivy: finish generalized indexing, fix shape of index result

### DIFF
--- a/testdata/binary_vector.ivy
+++ b/testdata/binary_vector.ivy
@@ -447,6 +447,34 @@
 1 2 3 4[down 1 2 3 4]
 	4 3 2 1
 
+rho 11 22 33[3 2 1]
+	3
+
+rho 11 22 33[2 3]
+	2
+
+rho 11 22 33[2]
+	0
+
+rho 11 22 33[1 rho 2]
+	1
+
+(6 2 rho "abcdefghijkl") [3 2 rho iota 6]
+	ab
+	cd
+	
+	ef
+	gh
+	
+	ij
+	kl
+
+rho (6 2 rho "abcdefghijkl") [3 2 rho iota 6]
+	3 2 2
+
+x = 1 rho 1; rho x[up x]
+	1
+
 3 sel 1
 	1 1 1
 

--- a/testdata/exec_fail.ivy
+++ b/testdata/exec_fail.ivy
@@ -31,3 +31,19 @@ x
 # invalid code points in string
 '\x80'
 	X
+
+# cannot index int
+1[1]
+	X
+
+# cannot index rational
+1/2 [1]
+	X
+
+# cannot index float
+(log 2)[1]
+	X
+
+# index must be integer
+1 2[1 2 log 2]
+	X

--- a/value/eval.go
+++ b/value/eval.go
@@ -110,6 +110,88 @@ func (op *binaryOp) EvalBinary(c Context, u, v Value) Value {
 	return fn(c, u, v)
 }
 
+// index computes u[v].
+// v is known to be an int, vector, or matrix.
+// u could be anything.
+// The rank of the result depends only on the rank of u and v,
+// not on the actual data.
+// For example, if u is a vector and v is a vector,
+// then u[v] is always a vector, even if v has only one element.
+// Giving each expression a rank that depends only on the
+// input ranks, and not on the actual indexes, is important
+// for avoiding indexing problems in user-defined operators.
+func index(c Context, u, v Value) Value {
+	var Astride Int
+	var Adata Vector
+	switch A := u.(type) {
+	case Vector:
+		Astride = 1
+		Adata = A
+	case *Matrix:
+		Astride = Int(len(A.data) / A.shape[0])
+		Adata = A.data
+	default:
+		Errorf("cannot index %v", whichType(u))
+	}
+
+	// Collect indexed values.
+	origin := Int(c.Config().Origin())
+	var data Vector
+	switch v.(type) {
+	default:
+		Errorf("index must be integer")
+	case Int:
+		B := v.(Int)
+		B -= origin
+		if B < 0 || B >= Int(len(Adata))/Astride {
+			Errorf("index %d out of range", B+origin)
+		}
+		data = append(data, Adata[B*Astride:(B+1)*Astride]...)
+	case Vector, *Matrix:
+		var Bdata []Value
+		switch B := v.(type) {
+		case Vector:
+			Bdata = B
+		case *Matrix:
+			Bdata = B.data
+		}
+		data = make([]Value, 0, Int(len(Bdata))*Astride)
+		for i := range Bdata {
+			b, ok := Bdata[i].(Int)
+			if !ok {
+				Errorf("index must be integer")
+			}
+			b -= origin
+			if b < 0 || b >= Int(len(Adata))/Astride {
+				Errorf("index %d out of range", b+origin)
+			}
+			data = append(data, Adata[b*Astride:(b+1)*Astride]...)
+		}
+	}
+
+	// Shape of result of A[B] is the shape of B + shape of A[i].
+	var shape []int
+	switch B := v.(type) {
+	case Vector:
+		shape = []int{len(B)}
+	case *Matrix:
+		shape = append(shape, B.shape...)
+	}
+	switch A := u.(type) {
+	case *Matrix:
+		shape = append(shape, A.shape[1:]...)
+	}
+
+	switch len(shape) {
+	case 0:
+		return data[0]
+	case 1:
+		return data // vector
+	default:
+		return NewMatrix(shape, data)
+	}
+}
+
 // Product computes a compound product, such as an inner product
 // "+.*" or outer product "o.*". The op is known to contain a
 // period. The operands are all at least vectors, and for inner product


### PR DESCRIPTION
Generalized indexing like 'ab'[3 3 rho 1 2] handled a few special cases.
Make it handle all cases, simplifying the code. Also fix a few small
semantic problems in the process.

For example:

Indexing a vector by a vector produces a vector nearly all the time.
This CL changes that to all the time, so that programs can have a
consistent expectation about the rank of the result and whether
it can be indexed. For example, suppose we have a vector of values
and want to extract the positive ones, extract those indexes from
a vector v, and then sort v.

	v = v[(x > 0) sel x]
	v = v[up v]

(x > 0) sel x is always a vector. If it has length > 1, then v[(x > 0) sel x]
is always a vector. But if it has length == 1, then before this CL,
v[(x > 0) sel x] was a scalar, not a vector, making the indexing in
v[up v] disallowed.

The shrinking of v in the single-element vector case was important
because it made v[1] be a scalar: the code promoted both v and i
in v[i] to the same overall type, meaning the scalar 1 was promoted
to a vector 1, and then v[1] needed to drop the result back to scalar
to be useful. Taking advantage of the recently added ability to have
different types for the two parts, this CL drops the promotion and
then preserves the form.

There were also a few other lesser surprises arising from promoting
both v and i in v[i] to the same overall type. For example (before this CL):

	1[1]

	1[1 2 3]

Now both of those are diagnosed as erroneous.

These semantic problems are now tested, and the cleanup and changes
did not affect any existing test, suggesting that all the important
behaviors have been preserved.