### PR TITLE
ivy: optimize binary 'in' operator

### DIFF
--- a/testdata/binary_vector.ivy
+++ b/testdata/binary_vector.ivy
@@ -644,3 +644,7 @@ circle 10
 
 10 decode 3 3 rho iota 9
 	147 258 369
+
+# takes 30 seconds if quadratic
++/ (iota 30000) in iota 30000
+	30000

--- a/value/vector.go
+++ b/value/vector.go
@@ -166,13 +166,34 @@ func (v Vector) reverse() Vector {
 // whether each element is an element of v.
 // TODO: N*M algorithm - can we do better?
 func membership(c Context, u, v Vector) []Value {
+	have := make(map[Value]bool)
+	var extra []Value
+	for _, y := range v {
+		switch y.(type) {
+		case Char, Int:
+			have[y] = true
+		default:
+			extra = append(extra, y)
+		}
+	}
+
 	values := make([]Value, len(u))
 	for i, x := range u {
+		if shrinker, ok := x.(interface{ shrink() Value }); ok {
+			x = shrinker.shrink()
+		}
 		values[i] = Int(0)
-		for _, y := range v {
-			if c.EvalBinary(x, "==", y) == Int(1) {
+		switch x.(type) {
+		case Char, Int:
+			if have[x] {
 				values[i] = Int(1)
-				break
+			}
+		default:
+			for _, y := range extra {
+				if c.EvalBinary(x, "==", y) == Int(1) {
+					values[i] = Int(1)
+					break
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The old 'in' implementation took quadratic time,
which makes (iota 30000) in iota 30000 take 30 seconds
on my 2021 MacBook Pro.

This map-based implementation runs in a fraction of a second.
For very large or fractional values it degrades back to the quadratic
lookup.