### PR TITLE
ivy: fix multi-frame variable lookup bug

### DIFF
--- a/testdata/function.ivy
+++ b/testdata/function.ivy
@@ -28,6 +28,15 @@ op double u = x = u; x*2
 double 3; x
 	6 3
 
+# in g calling f, f used to assign to global y but read from g's y.
+op f x = y = 99; y
+op g y = f y
+g 42
+y = 10
+g 42
+	99
+	99
+
 # Declare unary before use
 op foo x
 op bar x = foo x


### PR DESCRIPTION
If g is calling f, f should never read or write g's variables.
But that's what Lookup was doing: reading g's variables
instead of globals of the same name. Assignment was correct.
This change factors out the lookup to share it between both.
