### PR TITLE
ivy: use parallel execution when possible

### DIFF
--- a/ivy_test.go
+++ b/ivy_test.go
@@ -16,11 +16,16 @@ import (
 	"robpike.io/ivy/config"
 	"robpike.io/ivy/exec"
 	"robpike.io/ivy/run"
+	"robpike.io/ivy/value"
 )
 
 const verbose = false
 
 var testConf config.Config
+
+func init() {
+	value.MaxParallelismForTesting()
+}
 
 // Note: These tests share some infrastructure and cannot run in parallel.
 

--- a/value/vector.go
+++ b/value/vector.go
@@ -7,6 +7,7 @@ package value
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"sort"
 
 	"robpike.io/ivy/config"
@@ -128,13 +129,8 @@ func (v Vector) rotate(n int) Value {
 }
 
 func doRotate(dst, src []Value, j int) {
-	for i := range dst {
-		dst[i] = src[j]
-		j++
-		if j >= len(src) {
-			j = 0
-		}
-	}
+	n := copy(dst, src[j:])
+	copy(dst[n:n+j], src[:j])
 }
 
 // grade returns as a Vector the indexes that sort the vector into increasing order
@@ -168,9 +164,12 @@ func (v Vector) reverse() Vector {
 func membership(c Context, u, v Vector) []Value {
 	values := make([]Value, len(u))
 	sortedV := v.sortedCopy(c)
-	for i, x := range u {
-		values[i] = toInt(sortedV.contains(c, x))
-	}
+	work := 2 * (1 + int(math.Log2(float64(len(v)))))
+	pfor(true, work, len(values), func(lo, hi int) {
+		for i := lo; i < hi; i++ {
+			values[i] = toInt(sortedV.contains(c, u[i]))
+		}
+	})
 	return values
 }
 


### PR DESCRIPTION
At least for built-in functions, element-wise or row-wise
operations can safely run each element/row in parallel.
This lets Ivy use all of a computer instead of 1 core.

On my 8-physical, 16-logical core MacBook Pro:

```
% echo '+/+/+/2*(500 500 500 rho 1)*(iota 500)' | time ./ivy.old
62625000000

       35.34 real        45.45 user         6.66 sys
% echo '+/+/+/2*(500 500 500 rho 1)*(iota 500)' | time ./ivy.new
62625000000

        8.27 real        84.08 user         8.75 sys
%
```

I don't believe the doubled user time is real.
It is counting logical-core-user-time, and the two logical cores
are both running and are therefore running at half speed.
That is, using the 16 cores is mostly the same as:

```
% echo '+/+/+/2*(500 500 500 rho 1)*(iota 500)' |  GOMAXPROCS=8 time ./ivy.new
62625000000

        8.27 real        44.89 user         5.00 sys
%
```

except of course for the bad accounting.

Passes 'go test -race' but only in Go dev branch
(needs CL 375935 fixing math/big).