### PR TITLE
ivy: make scan linear for associative operators

### DIFF
--- a/testdata/scan.ivy
+++ b/testdata/scan.ivy
@@ -23,6 +23,10 @@
 -\iota 10
 	1 -1 2 -2 3 -3 4 -4 5 -5
 
+# associative scan should run in linear time - this takes ~10m if quadratic
++/ +\ iota 100000
+	166671666700000
+
 # Matrices
 
 +\3 4 rho iota 100


### PR DESCRIPTION
Scan is in general a quadratic operation, but associative operators
(arguably the most useful ones for a scan) can run in linear time instead
by working left-to-right and reusing results, instead of right-to-left.

For example:

	+\ iota 100000

runs in a small fraction of a second left-to-right
but takes about 10 minutes right-to-left.

Work left-to-right for known associative operators for speed.