### PR TITLE
ivy: fix divide by zero in parallel binary transp with zero dimension

### DIFF
--- a/testdata/binary_matrix.ivy
+++ b/testdata/binary_matrix.ivy
@@ -739,6 +739,9 @@ i = iota 6
 	 1  2  3  4
 	17 18 19 20
 
+rho transp 1 0 2 rho 0
+	2 0 1
+
 2 0 1 sel (2 3 rho iota 6)
 	1 1 3
 	4 4 6

--- a/value/matrix.go
+++ b/value/matrix.go
@@ -486,8 +486,10 @@ func (m *Matrix) binaryTranspose(c Context, v Vector) *Matrix {
 		index := make([]int, rank)
 		i := lo
 		for j := rank - 1; j >= 0; j-- {
-			index[j] = i % shape[j]
-			i /= shape[j]
+			if shape[j] > 0 {
+				index[j] = i % shape[j]
+				i /= shape[j]
+			}
 		}
 		for i := lo; i < hi; i++ {
 			// Compute old index for this new entry.


### PR DESCRIPTION
This used to crash with a divide-by-zero due to the new
“start in the middle” calculation for the parallel case.

	rho transp 1 0 2 rho 0
		2 0 1

Don't do that.