### PR TITLE
ivy: print real, user, and system time in )debug cpu

### DIFF
--- a/run/time_unix.go
+++ b/run/time_unix.go
@@ -1,0 +1,25 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package run
+
+import (
+	"syscall"
+	"time"
+)
+
+func init() {
+	cpuTime = rusageTime
+}
+
+func rusageTime() (user, sys time.Duration) {
+	var rusage syscall.Rusage
+	err := syscall.Getrusage(syscall.RUSAGE_SELF, &rusage)
+	if err != nil {
+		return 0, 0
+	}
+	return time.Duration(rusage.Utime.Nano()), time.Duration(rusage.Stime.Nano())
+}


### PR DESCRIPTION
Now that ivy can run on multiple CPUs,
it can be interesting to see exactly how
much of the machine is being used.
This commit adds user and system time
to the )debug cpu print, on systems that can.