### PR TITLE
ivy: fix )save of new index expression, multiline functions

### DIFF
--- a/parse/function.go
+++ b/parse/function.go
@@ -141,6 +141,11 @@ func doReferences(c *exec.Context, refs *[]exec.OpDef, expr value.Expr) {
 		doBinaryReferences(c, refs, e.binary)
 	case *binary:
 		doBinaryReferences(c, refs, e)
+	case *index:
+		doReferences(c, refs, e.left)
+		for _, v := range e.right {
+			doReferences(c, refs, v)
+		}
 	case variableExpr:
 	case sliceExpr:
 		for _, v := range e {

--- a/parse/save.go
+++ b/parse/save.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strings"
 
 	"robpike.io/ivy/config"
 	"robpike.io/ivy/exec"
@@ -100,7 +101,12 @@ func save(c *exec.Context, file string) {
 			}
 		}
 		printed[def] = true
-		fmt.Fprintln(out, fn) // TODO: Does this need conf?
+		s := fn.String() // TODO: Does this need conf?
+		if strings.Contains(s, "\n") {
+			// Multiline def must end in blank line.
+			s += "\n"
+		}
+		fmt.Fprintln(out, s)
 	}
 
 	// Global variables.

--- a/testdata/save.ivy
+++ b/testdata/save.ivy
@@ -89,3 +89,42 @@ avg x
 	1 2 3 4 5 6 7
 	4
 
+# Indexing operations
+op g x = x
+op f x = x[1 2; g 3 4; 5 6]
+)save "<conf.out>"
+	)prec 256
+	)maxbits 1000000000
+	)maxdigits 10000
+	)origin 1
+	)prompt ""
+	)format ""
+	op g x = x
+	op f x = x[1 2; g 3 4; 5 6]
+	# Set base 10 for parsing numbers.
+	)base 10
+	)ibase 0
+	)obase 0
+
+# Multiline function definitions.
+op f x =
+ x==1: 2
+ x
+ 
+op g x = x
+)save "<conf.out>"
+	)prec 256
+	)maxbits 1000000000
+	)maxdigits 10000
+	)origin 1
+	)prompt ""
+	)format ""
+	op f x =
+		(x == 1) : 2
+		x
+	
+	op g x = x
+	# Set base 10 for parsing numbers.
+	)base 10
+	)ibase 0
+	)obase 0


### PR DESCRIPTION
The new index expression was not accounted for in the
reference walk. This commit adds that.

Also, multiline functions were not followed by a blank line
in the save output, meaning that the output of )save
could not be parsed back with )get. This commit adds a
blank line in )save.

I considered adding a blank line to Function.String,
but that changed the output of )op f to end in two blank lines,
one provided by Function.String and one provided by the
interpreter loop. That seemed like too much, so I put the
special case into )save itself.