### PR TITLE
run: add // +build comment to fix build on go 1.16

### DIFF
--- a/run/time_unix.go
+++ b/run/time_unix.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 //go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package run
 


### PR DESCRIPTION
Per the go 1.16 directive in the go.mod, fix the error

	//go:build comment without // +build comment

encountered on go 1.16 by adding the legacy build comment.