### PR TITLE
ivy: bring panics back to main goroutine in pfor

### DIFF
--- a/testdata/exec_fail.ivy
+++ b/testdata/exec_fail.ivy
@@ -47,3 +47,9 @@ x
 # index must be integer
 1 2[1 2 log 2]
 	X
+
+1 / 0
+	X
+
+1 / 2 2 rho 0
+	X


### PR DESCRIPTION
This handles panics for problems like 'division by zero'.

Fixes #103.