### PR TITLE
improve ivy usage in scripts

### DIFF
--- a/ivy.go
+++ b/ivy.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime/pprof"
 	"strings"
 
 	"robpike.io/ivy/config"
@@ -43,10 +42,6 @@ var (
 func main() {
 	flag.Usage = usage
 	flag.Parse()
-
-	f, _ := os.Create("/tmp/ivy.prof")
-	pprof.StartCPUProfile(f)
-	defer pprof.StopCPUProfile()
 
 	if *origin < 0 {
 		fmt.Fprintf(os.Stderr, "ivy: illegal origin value %d\n", *origin)

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -1,0 +1,22 @@
+//go:build aix || darwin || dragonfly || freebsd || hurd || linux || netbsd || openbsd
+
+package main
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func init() {
+	isTTY = isatty
+}
+
+func isatty(fd uintptr) bool {
+	// size of winsize struct, we only need the syscall error code.
+	// https://pkg.go.dev/golang.org/x/sys@v0.6.0/unix#Winsize
+	// ioctl_tty(2)
+	p := [4]uint16{}
+	_, _, e1 := syscall.Syscall(syscall.SYS_IOCTL, fd, syscall.TIOCGWINSZ,
+		uintptr(unsafe.Pointer(&p[0])))
+	return e1 == 0
+}


### PR DESCRIPTION
recent changes made in ivy made it always write cpu profiles in /tmp, even in my system tmp being a ramfs, i noticed a substantial slowdown in some scripts i have using ivy, i did what most things in go ecosystem do which is turn off by default and enable it with a flag, while doing this i also merge an old change i made to stop printing an extra new line when reading stdin from pipes, this saves an extra `| sed` i had to use to remove them, but the only annoying piece is the slowdown to exit ivy, i'm ok if you just cherry-pick this change.

BR.
