### PR TITLE
Fix `base` op example in demo

### DIFF
--- a/demo/demo.ivy
+++ b/demo/demo.ivy
@@ -227,7 +227,7 @@ op n largest x = n take x[down x]
 3 largest ? 100 rho 1000
 4 largest 'hello world'
 # Population count. Use encode to turn the value into a string of bits. Use log to decide how many.
-op a base b = ((ceil b log a) rho b) encode a
+op a base b = ((floor 1 + b log a) rho b) encode a
 7 base 2
 op popcount n = +/n base 2
 popcount 7


### PR DESCRIPTION
The op `base` doesn't work properly with numbers that are power of the base.

For example:
```
8 base 2
0 0 0

9 base 3
0 0
```

This is caused by a mismatch between the log operation that return the power and the representation that in this case need a one more number.

This is evident in the op `popcount` that with the powers of two doesn't work:
```
popcount 8
0

popcount 16
0

popcount 32
0

popcount 64
0
```
