### PR TITLE
ivy: close profile file

### DIFF
--- a/ivy.go
+++ b/ivy.go
@@ -51,7 +51,12 @@ func main() {
 			fmt.Fprintf(os.Stderr, "ivy: cannot create profile file: %v\n", err)
 			os.Exit(2)
 		}
-		pprof.StartCPUProfile(f)
+		defer f.Close()
+		err = pprof.StartCPUProfile(f)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ivy: cannot start CPU profile: %v\n", err)
+			os.Exit(2)
+		}
 		defer pprof.StopCPUProfile()
 	}
 


### PR DESCRIPTION
Balance out `f.Create` with an `f.Close`.

Also bail out if `StartCPUProfile` returns a non-`nil` error while here.

I'm not sure if this matters or is helpful, but figured I'd ask by sending this PR.
(Issue golang/go#26970 suggests there may be some benefit.)