### PR TITLE
ivy: fix nil panic on indexed assignment of rationals, floats or big ints

### DIFF
--- a/testdata/statement.ivy
+++ b/testdata/statement.ivy
@@ -121,6 +121,10 @@ x = 1 2 3; x[2] = 3 4 5; x
 x = 1 2 3; y = 4 5 6; x[2] = y; y[1] = 8; x
 	1 (4 5 6) 3
 
+# Test that assignment works with rationals, floats and big integers.
+x = 1 2 3; x[1] = 1/2; x[2] = float 0.5; x[3] = 10000000000; x
+	1/2 0.5 10000000000
+
 # Assignment is an expression.
 1 + y = 100
 	101

--- a/value/bigfloat.go
+++ b/value/bigfloat.go
@@ -132,9 +132,9 @@ func (f BigFloat) Eval(Context) Value {
 }
 
 func (f BigFloat) Copy() Value {
-	x := new(big.Float)
+	var x big.Float
 	x.Set(f.Float)
-	return BigFloat{x}
+	return BigFloat{&x}
 }
 
 func (f BigFloat) Inner() Value {

--- a/value/bigfloat.go
+++ b/value/bigfloat.go
@@ -132,7 +132,7 @@ func (f BigFloat) Eval(Context) Value {
 }
 
 func (f BigFloat) Copy() Value {
-	var x *big.Float
+	x := new(big.Float)
 	x.Set(f.Float)
 	return BigFloat{x}
 }

--- a/value/bigint.go
+++ b/value/bigint.go
@@ -135,9 +135,9 @@ func (i BigInt) Eval(Context) Value {
 }
 
 func (i BigInt) Copy() Value {
-	x := new(big.Int)
+	var x big.Int
 	x.Set(i.Int)
-	return BigInt{x}
+	return BigInt{&x}
 }
 
 func (i BigInt) Inner() Value {

--- a/value/bigint.go
+++ b/value/bigint.go
@@ -135,7 +135,7 @@ func (i BigInt) Eval(Context) Value {
 }
 
 func (i BigInt) Copy() Value {
-	var x *big.Int
+	x := new(big.Int)
 	x.Set(i.Int)
 	return BigInt{x}
 }

--- a/value/bigrat.go
+++ b/value/bigrat.go
@@ -168,7 +168,7 @@ func (r BigRat) Eval(Context) Value {
 }
 
 func (r BigRat) Copy() Value {
-	var x *big.Rat
+	x := new(big.Rat)
 	x.Set(r.Rat)
 	return BigRat{x}
 }

--- a/value/bigrat.go
+++ b/value/bigrat.go
@@ -168,9 +168,9 @@ func (r BigRat) Eval(Context) Value {
 }
 
 func (r BigRat) Copy() Value {
-	x := new(big.Rat)
+	var x big.Rat
 	x.Set(r.Rat)
-	return BigRat{x}
+	return BigRat{&x}
 }
 
 func (r BigRat) Inner() Value {


### PR DESCRIPTION
Indexed assignment did not work for rationals, floats, and big integers because in the Copy methods of the types BigRat, BigFloat, and BigInt, relevant variables were not allocated before being used, leading to a nil panic. The following assignments now work:

    x = iota 3
    x[1] = 1/2
    x[2] = float 0.5
    x[3] = 10000000000