### PR TITLE
ivy: fix function undefinition

### DIFF
--- a/parse/function.go
+++ b/parse/function.go
@@ -57,10 +57,10 @@ func (p *Parser) functionDefn() {
 		p.errorf("argument name %q is function name", fn.Name)
 	}
 	// Define it, but prepare to undefine if there's trouble.
+	prevDefn := installMap[fn.Name]
 	p.context.Define(fn)
 	defer p.context.ForgetAll()
 	succeeded := false
-	prevDefn := installMap[fn.Name]
 	defer func() {
 		if !succeeded {
 			if prevDefn == nil {

--- a/testdata/exec_fail.ivy
+++ b/testdata/exec_fail.ivy
@@ -48,3 +48,12 @@ x
 # shape mismatch (4) != (2) in assignment x[2] = 3 4 5
 x = 3 4 rho iota 12; x[1]=1 2
 	X
+
+# unexpected EOF
+# undefined global variable "inc"
+op inc b =
+ b + 1
+ |
+
+inc 1
+	X


### PR DESCRIPTION
Function undefinition did not work because the previous definition was overwritten before being saved, and so restoring it was a no-op.

This meant functions with intermediate state could be produced, potentially violating invariants. For example, the following creates a function with a partial body but without any locals, eventually leading to an index out of range when trying to access the local `b`:

```
op inc b =
  b + 1
  |

inc 1
```

```
$ ivy <crash.ivy
unexpected EOF


panic: runtime error: index out of range [-1] [recovered]
        panic: runtime error: index out of range [-1]

goroutine 1 [running]:
...
```