### PR TITLE
ivy: add a missing line in the help text about user-defined operators

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -324,6 +324,7 @@ To write to a global without reading it first, insert an unused read.
 		total = total + x  # total is global because total is read before written
 		last; last = x     # unused read makes last global
 
+	save 9; save 3
 	total last
 	result: 12 3
 

--- a/mobile/help.go
+++ b/mobile/help.go
@@ -308,6 +308,7 @@ op save x =
 	total = total + x  # total is global because total is read before written
 	last; last = x     # unused read makes last global
 
+save 9; save 3
 total last
 result: 12 3
 </pre>

--- a/parse/help.go
+++ b/parse/help.go
@@ -320,6 +320,7 @@ var helpLines = []string{
 	"\t\ttotal = total + x  # total is global because total is read before written",
 	"\t\tlast; last = x     # unused read makes last global",
 	"",
+	"\tsave 9; save 3",
 	"\ttotal last",
 	"\tresult: 12 3",
 	"",


### PR DESCRIPTION
The example in the help text about global variables in user-defined operators was lacking the actual operator calls.
Without this line, the described result wouldn't be produced.