### PR TITLE
Require Go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module robpike.io/ivy
 
-go 1.17
+go 1.21


### PR DESCRIPTION
Commit f024fcaf17 uses math/big.Int.Float64 which was introduced in Go version 1.21