### PR TITLE
value: add BigInt.Float64 for Go 1.20 and older

### DIFF
--- a/value/bigint_go120.go
+++ b/value/bigint_go120.go
@@ -1,0 +1,32 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !go1.21
+
+package value
+
+import "math/big"
+
+// Float64 returns the float64 value nearest x,
+// and an indication of any rounding that occurred.
+//
+// The implementation is backported from Go 1.21.0's
+// math/big.Int.Float64 implementation.
+func (i BigInt) Float64() (float64, big.Accuracy) {
+	n := i.Int.BitLen()
+	if n == 0 {
+		return 0.0, big.Exact
+	}
+
+	// Fast path: no more than 53 significant bits.
+	if n <= 53 || n < 64 && n-int(i.Int.TrailingZeroBits()) <= 53 {
+		f := float64(i.Int.Uint64())
+		if i.Int.Sign() == -1 {
+			f = -f
+		}
+		return f, big.Exact
+	}
+
+	return new(big.Float).SetInt(i.Int).Float64()
+}


### PR DESCRIPTION
In Go 1.21, `big.Int` got a new method `Float64` (proposal golang/go#56984).
In Go 1.21, `BigInt` has that method because it embeds `*big.Int`.
In Go 1.20 and older, it's possible to implement it ourselves.

The README and go.mod say that ivy requires Go 1.17 to be built, so
add the `Float64` implementation with an appropriate build constraint.