### PR TITLE
ivy: reset 'maxstack' between test runs

### DIFF
--- a/ivy_test.go
+++ b/ivy_test.go
@@ -180,6 +180,7 @@ func reset() {
 	testConf.SetFormat("")
 	testConf.SetMaxBits(1e9)
 	testConf.SetMaxDigits(1e4)
+	testConf.SetMaxStack(100000)
 	testConf.SetOrigin(1)
 	testConf.SetPrompt("")
 	testConf.SetBase(0, 0)


### PR DESCRIPTION
This ensures that tests are independent of the execution order of test files.

Fixes #150