### PR TITLE
Fix fmt.Sprint typo

### DIFF
--- a/value/sys.go
+++ b/value/sys.go
@@ -156,7 +156,7 @@ func decodeTime(c Context, u, v Vector) Value {
 		if offset != nowOffset {
 			hour := offset / 3600
 			min := (offset - (3600 * hour)) / 60
-			loc = time.FixedZone(fmt.Sprint("%d:%02d", hour, min), offset)
+			loc = time.FixedZone(fmt.Sprintf("%d:%02d", hour, min), offset)
 		}
 		fallthrough
 	case 6:


### PR DESCRIPTION
Noticed via

	$ go test ./...
	# robpike.io/ivy/value
	value/sys.go:159:25: fmt.Sprint call has possible Printf
	formatting directive %d