### PR TITLE
ivy: allow quoted string argument in help, help about

### DIFF
--- a/parse/special.go
+++ b/parse/special.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -152,9 +153,21 @@ Switch:
 				p.helpOverview()
 				break
 			}
-			p.helpAbout(tok.Text)
+			text := tok.Text
+			if tok.Type == scan.String {
+				if s, err := strconv.Unquote(text); err == nil {
+					text = s
+				}
+			}
+			p.helpAbout(text)
 		default:
-			p.help(str)
+			text := tok.Text
+			if tok.Type == scan.String {
+				if s, err := strconv.Unquote(text); err == nil {
+					text = s
+				}
+			}
+			p.help(text)
 		}
 		p.next()
 	case "base", "ibase", "obase":


### PR DESCRIPTION
Right now if you do

	)help about +

you have to type enter twice before Ivy realizes more isn't coming.

This CL makes

	)help about "+"

work with just one enter. It will also help with

	)help about "@"

because

	)help about @

is a syntax error.