### PR TITLE
ivy: optimize away some Int -> Value allocations

### DIFF
--- a/value/binary.go
+++ b/value/binary.go
@@ -188,7 +188,7 @@ func andBool(t Value) bool {
 		}
 		return true
 	}
-	return t.(Int) == one
+	return t.(Int) == 1
 }
 
 var BinaryOps = make(map[string]BinaryOp)
@@ -221,6 +221,14 @@ func init() {
 			whichType:   binaryArithType,
 			fn: [numType]binaryFn{
 				intType: func(c Context, u, v Value) Value {
+					// Avoid Int->Value interface allocation;
+					// especially effective for sparse matrices.
+					if u.(Int) == 0 {
+						return v
+					}
+					if v.(Int) == 0 {
+						return u
+					}
 					return (u.(Int) + v.(Int)).maybeBig()
 				},
 				bigIntType: func(c Context, u, v Value) Value {
@@ -246,6 +254,11 @@ func init() {
 			whichType:   binaryArithType,
 			fn: [numType]binaryFn{
 				intType: func(c Context, u, v Value) Value {
+					// Avoid Int->Value interface allocation;
+					// especially effective for sparse matrices.
+					if v.(Int) == 0 {
+						return u
+					}
 					return (u.(Int) - v.(Int)).maybeBig()
 				},
 				bigIntType: func(c Context, u, v Value) Value {
@@ -271,6 +284,14 @@ func init() {
 			whichType:   binaryArithType,
 			fn: [numType]binaryFn{
 				intType: func(c Context, u, v Value) Value {
+					// Avoid Int->Value interface allocation;
+					// especially effective for sparse matrices.
+					if u.(Int) == 1 || v.(Int) == 0 {
+						return v
+					}
+					if v.(Int) == 1 || u.(Int) == 0 {
+						return u
+					}
 					return (u.(Int) * v.(Int)).maybeBig()
 				},
 				bigIntType: func(c Context, u, v Value) Value {
@@ -515,6 +536,14 @@ func init() {
 			whichType:   binaryArithType,
 			fn: [numType]binaryFn{
 				intType: func(c Context, u, v Value) Value {
+					// Avoid Int->Value interface allocation;
+					// especially effective for sparse matrices.
+					if u.(Int) == 0 || v.(Int) == -1 {
+						return u
+					}
+					if v.(Int) == 0 || u.(Int) == -1 {
+						return v
+					}
 					return u.(Int) & v.(Int)
 				},
 				bigIntType: func(c Context, u, v Value) Value {
@@ -529,6 +558,14 @@ func init() {
 			whichType:   binaryArithType,
 			fn: [numType]binaryFn{
 				intType: func(c Context, u, v Value) Value {
+					// Avoid Int->Value interface allocation;
+					// especially effective for sparse matrices.
+					if u.(Int) == 0 || v.(Int) == -1 {
+						return v
+					}
+					if v.(Int) == 0 || u.(Int) == -1 {
+						return u
+					}
 					return u.(Int) | v.(Int)
 				},
 				bigIntType: func(c Context, u, v Value) Value {
@@ -543,6 +580,14 @@ func init() {
 			whichType:   binaryArithType,
 			fn: [numType]binaryFn{
 				intType: func(c Context, u, v Value) Value {
+					// Avoid Int->Value interface allocation;
+					// especially effective for sparse matrices.
+					if u.(Int) == 0 {
+						return v
+					}
+					if v.(Int) == 0 {
+						return u
+					}
 					return u.(Int) ^ v.(Int)
 				},
 				bigIntType: func(c Context, u, v Value) Value {

--- a/value/const.go
+++ b/value/const.go
@@ -26,10 +26,13 @@ const (
 	constPrecisionInDigits = 3011
 )
 
-const (
-	zero     Int = 0
-	one      Int = 1
-	minusOne Int = -1
+// Note: These are pre-allocated Values (interfaces) so that
+// code that needs to return a Value can 'return zero'
+// instead of 'return Int(0)' and avoid an allocation.
+var (
+	zero     Value = Int(0)
+	one      Value = Int(1)
+	minusOne Value = Int(-1)
 )
 
 var (

--- a/value/matrix.go
+++ b/value/matrix.go
@@ -377,7 +377,7 @@ func reshape(A, B Vector) Value {
 	if len(A) == 0 {
 		return Vector{}
 	}
-	nelems := one
+	nelems := Int(1)
 	shape := make([]int, len(A))
 	for i := range A {
 		n, ok := A[i].Inner().(Int)


### PR DESCRIPTION
These cases are particularly common when operating on large boolean matrices. Avoid significant amounts of garbage allocating zeros and ones.

Commit ded8201e changed zero and one from Value to Int saying "No reason not to, and it takes a few bytes out of the binary". The reason not to is to avoid allocations, so add a comment to that effect.