### PR TITLE
ivy: fix split of matrix with 0-length dimension

### DIFF
--- a/testdata/unary_matrix.ivy
+++ b/testdata/unary_matrix.ivy
@@ -406,3 +406,11 @@ split 2 3 4 rho iota 99
 iota rho 1 1 1
 	1 2 3
 
+split 1 2 rho iota 2
+	(1 2)
+
+split 1 1 rho iota 1
+	(1)
+
+split 1 0 rho iota 0
+	()

--- a/value/matrix.go
+++ b/value/matrix.go
@@ -892,12 +892,12 @@ func (m *Matrix) split() Value {
 		Errorf("cannot split rank %d matrix", len(m.shape))
 	}
 	// Matrix of vectors.
-	n := m.shape[len(m.shape)-1]
-	mData := make([]Value, 0, size(m.shape[:len(m.shape)-1]))
-	for i := 0; i < len(m.data); i += n {
-		mData = append(mData, NewVector(m.data[i:i+n]))
+	shape, n := m.shape[:len(m.shape)-1], m.shape[len(m.shape)-1]
+	mData := make([]Value, size(shape))
+	for i := range mData {
+		mData[i] = NewVector(m.data[i*n : (i+1)*n])
 	}
-	return NewMatrix(m.shape[:len(m.shape)-1], mData).shrink()
+	return NewMatrix(shape, mData).shrink()
 }
 
 // mix builds a matrix from the elements of the nested matrix.


### PR DESCRIPTION
Split was mishandling a matrix with final dimension 0.

Before:

	split 1 2 rho iota 2
		(1 2)

	split 1 1 rho iota 1
		(1)

	split 1 0 rho iota 0
		inconsistent shape ([1]) and data size (0) for new matrix

After:

	split 1 2 rho iota 2
		(1 2)

	split 1 1 rho iota 1
		(1)

	split 1 0 rho iota 0
		()