### PR TITLE
ivy: make Vector an opaque type instead of a slice

### DIFF
--- a/exec/context.go
+++ b/exec/context.go
@@ -76,7 +76,7 @@ func (c *Context) Local(i int) value.Value {
 // AssignLocal assigns the local variable with the given index the value.
 func (c *Context) AssignLocal(i int, val value.Value) {
 	switch v := val.(type) {
-	case value.Vector:
+	case *value.Vector:
 		val = v.Copy()
 	case *value.Matrix:
 		val = v.Copy()
@@ -89,7 +89,7 @@ func (c *Context) AssignLocal(i int, val value.Value) {
 // Inside a function, new variables become locals.
 func (c *Context) AssignGlobal(name string, val value.Value) {
 	switch v := val.(type) {
-	case value.Vector:
+	case *value.Vector:
 		val = v.Copy()
 	case *value.Matrix:
 		val = v.Copy()

--- a/order_test.go
+++ b/order_test.go
@@ -62,12 +62,12 @@ var (
 	matrix12_44   = value.NewMatrix([]int{2, 2}, newMatrixData(1, 2, 4, 4))
 )
 
-func newMatrixData(data ...int) []value.Value {
+func newMatrixData(data ...int) *value.Vector {
 	v := make([]value.Value, len(data))
 	for i := range data {
 		v[i] = value.Int(data[i])
 	}
-	return v
+	return value.NewVector(v)
 }
 
 func TestOrderedCompare(t *testing.T) {

--- a/parse/assign.go
+++ b/parse/assign.go
@@ -56,16 +56,16 @@ func assignment(context value.Context, b *binary) value.Value {
 		}
 	case sliceExpr:
 		// Simultaneous assignment requires evaluation of RHS before assignment.
-		rhs, ok := b.right.Eval(context).Inner().(value.Vector)
+		rhs, ok := b.right.Eval(context).Inner().(*value.Vector)
 		if !ok {
 			value.Errorf("rhs of assignment to (%s) not a vector", lhs.ProgString())
 		}
-		if len(lhs) != len(rhs) {
+		if len(lhs) != rhs.Len() {
 			value.Errorf("length mismatch in assignment to (%s)", lhs.ProgString())
 		}
-		values := make([]value.Value, len(rhs))
-		for i := len(rhs) - 1; i >= 0; i-- {
-			values[i] = rhs[i].Eval(context).Inner()
+		values := make([]value.Value, rhs.Len())
+		for i := rhs.Len() - 1; i >= 0; i-- {
+			values[i] = rhs.At(i).Eval(context).Inner()
 		}
 		for i, v := range lhs {
 			vbl := v.(*variableExpr) // Guaranteed to be only a variable on LHS.

--- a/parse/function.go
+++ b/parse/function.go
@@ -246,7 +246,7 @@ func walk(expr value.Expr, assign bool, f func(value.Expr, bool)) {
 	case value.BigRat:
 	case value.BigFloat:
 	case value.Complex:
-	case value.Vector:
+	case *value.Vector:
 	case *value.Matrix:
 	default:
 		fmt.Printf("unknown %T in references\n", e)

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -179,7 +179,7 @@ func (e *variableExpr) ProgString() string {
 // may require parentheses around it when printed to maintain correct evaluation order.
 func isCompound(x interface{}) bool {
 	switch x := x.(type) {
-	case value.Char, value.Int, value.BigInt, value.BigRat, value.BigFloat, value.Complex, value.Vector, value.Matrix:
+	case value.Char, value.Int, value.BigInt, value.BigRat, value.BigFloat, value.Complex, *value.Vector, *value.Matrix:
 		return false
 	case sliceExpr, *variableExpr:
 		return false

--- a/parse/save.go
+++ b/parse/save.go
@@ -185,12 +185,12 @@ func put(conf *config.Config, out io.Writer, val value.Value, withParens bool) {
 		put(conf, out, real, false)
 		fmt.Fprintf(out, "j")
 		put(conf, out, imag, false)
-	case value.Vector:
+	case *value.Vector:
 		if val.AllChars() {
 			fmt.Fprintf(out, "%q", val.Sprint(conf))
 			return
 		}
-		for i, v := range val {
+		for i, v := range val.All() {
 			if i > 0 {
 				fmt.Fprint(out, " ")
 			}

--- a/testdata/debug.ivy
+++ b/testdata/debug.ivy
@@ -82,7 +82,7 @@ op a base b = ((ceil b log a) rho b) encode a
 	c
 
 1 2 3
-	value.Vector
+	*value.Vector
 	1 2 3
 
 sqrt 2

--- a/value/bigfloat.go
+++ b/value/bigfloat.go
@@ -163,7 +163,7 @@ func (f BigFloat) toType(op string, conf *config.Config, which valueType) Value 
 	case vectorType:
 		return oneElemVector(f)
 	case matrixType:
-		return NewMatrix([]int{1}, []Value{f})
+		return NewMatrix([]int{1}, NewVector([]Value{f}))
 	}
 	Errorf("%s: cannot convert float to %s", op, which)
 	return nil

--- a/value/bigint.go
+++ b/value/bigint.go
@@ -169,7 +169,7 @@ func (i BigInt) toType(op string, conf *config.Config, which valueType) Value {
 	case vectorType:
 		return oneElemVector(i)
 	case matrixType:
-		return NewMatrix([]int{1}, []Value{i})
+		return NewMatrix([]int{1}, NewVector([]Value{i}))
 	}
 	Errorf("%s: cannot convert big int to %s", op, which)
 	return nil

--- a/value/bigrat.go
+++ b/value/bigrat.go
@@ -199,7 +199,7 @@ func (r BigRat) toType(op string, conf *config.Config, which valueType) Value {
 	case vectorType:
 		return oneElemVector(r)
 	case matrixType:
-		return NewMatrix([]int{1, 1}, []Value{r})
+		return NewMatrix([]int{1, 1}, NewVector([]Value{r}))
 	}
 	Errorf("%s: cannot convert rational to %s", op, which)
 	return nil

--- a/value/char.go
+++ b/value/char.go
@@ -55,7 +55,7 @@ func (c Char) toType(op string, conf *config.Config, which valueType) Value {
 	case vectorType:
 		return oneElemVector(c)
 	case matrixType:
-		return NewMatrix([]int{1}, []Value{c})
+		return NewMatrix([]int{1}, NewVector([]Value{c}))
 	}
 	Errorf("%s: cannot convert char to %s", op, which)
 	return nil

--- a/value/complex.go
+++ b/value/complex.go
@@ -83,7 +83,7 @@ func (c Complex) toType(op string, conf *config.Config, which valueType) Value {
 	case vectorType:
 		return oneElemVector(c)
 	case matrixType:
-		return NewMatrix([]int{1, 1}, []Value{c})
+		return NewMatrix([]int{1, 1}, NewVector([]Value{c}))
 	}
 	Errorf("%s: cannot convert complex to %s", op, which)
 	return nil

--- a/value/fac.go
+++ b/value/fac.go
@@ -31,8 +31,9 @@ func primeGen(n int) func() int {
 // swing calculates the "swinging factorial" function of n,
 // which is n!/⌊n/2⌋!².
 // Swinging factorial table for reference.
-//		n  0 1 2 3 4  5  6   7  8   9  10   11
-//		n𝜎 1 1 2 6 6 30 20 140 70 630 252 2772
+//
+//	n  0 1 2 3 4  5  6   7  8   9  10   11
+//	n𝜎 1 1 2 6 6 30 20 140 70 630 252 2772
 func swing(n int) *big.Int {
 	nextPrime := primeGen(n)
 	factors := make([]int, 0, 100)

--- a/value/format.go
+++ b/value/format.go
@@ -39,12 +39,12 @@ func fmtText(c Context, u, v Value) Value {
 		formatOne(c, &b, format, verb, val.real)
 		b.WriteByte('j')
 		formatOne(c, &b, format, verb, val.imag)
-	case Vector:
+	case *Vector:
 		if val.AllChars() && strings.ContainsRune("boOqsvxX", rune(verb)) {
 			// Print the string as a unit.
 			fmt.Fprintf(&b, format, val.Sprint(debugConf))
 		} else {
-			for i, v := range val {
+			for i, v := range val.All() {
 				if i > 0 {
 					b.WriteByte(' ')
 				}
@@ -72,7 +72,7 @@ func formatString(c *config.Config, u Value) (string, byte) {
 	case Char:
 		s := fmt.Sprintf("%%%c", val)
 		return s, verbOf(s) // Error check is in there.
-	case Vector:
+	case *Vector:
 		if val.AllChars() {
 			s := val.Sprint(c)
 			if !strings.ContainsRune(s, '%') {
@@ -82,17 +82,17 @@ func formatString(c *config.Config, u Value) (string, byte) {
 			return s, verb
 		}
 		char := Char('f')
-		switch len(val) {
+		switch val.Len() {
 		case 1:
 			// Decimal count only.
-			dec, ok := val[0].(Int)
+			dec, ok := val.At(0).(Int)
 			if ok {
 				return fmt.Sprintf("%%.%df", dec), 'f'
 			}
 		case 3:
 			// Width count, and char.
 			var ok bool
-			char, ok = val[2].(Char)
+			char, ok = val.At(2).(Char)
 			if !ok {
 				break
 			}
@@ -103,8 +103,8 @@ func formatString(c *config.Config, u Value) (string, byte) {
 			fallthrough
 		case 2:
 			// Width and decimal count.
-			wid, ok1 := val[0].(Int)
-			dec, ok2 := val[1].(Int)
+			wid, ok1 := val.At(0).(Int)
+			dec, ok2 := val.At(1).(Int)
 			if ok1 && ok2 {
 				return fmt.Sprintf("%%%d.%d%c", wid, dec, char), byte(char)
 			}

--- a/value/int.go
+++ b/value/int.go
@@ -171,7 +171,7 @@ func (i Int) toType(op string, conf *config.Config, which valueType) Value {
 	case vectorType:
 		return oneElemVector(i)
 	case matrixType:
-		return NewMatrix([]int{1}, []Value{i})
+		return NewMatrix([]int{1}, NewVector([]Value{i}))
 	}
 	Errorf("%s: cannot convert int to %s", op, which)
 	return nil


### PR DESCRIPTION
This requires a very large number of mostly mechanical changes,
but now the code does not know that Vector is a slice, which
will allow optimizations like a copy-on-write implementation.
    
There is more work to do, but this is a large enough change
to be a reasonable checkpoint.
