### PR TITLE
ivy: allow comments in function definitions

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -392,7 +392,7 @@ func (p *Parser) readTokensToNewline(inFunction bool) bool {
 			p.errorf("%s", tok)
 		case scan.Newline:
 			// Need a truly blank line to terminate the function body.
-			if !inFunction || len(tok.Text) <= 1 {
+			if !inFunction || len(tok.Text) <= 1 || len(p.tokens) > 0 {
 				return true
 			}
 			continue

--- a/scan/scan.go
+++ b/scan/scan.go
@@ -243,13 +243,9 @@ func lexComment(l *Scanner) stateFn {
 	for {
 		r := l.next()
 		if r == eof || r == '\n' {
+			l.backup()
 			break
 		}
-	}
-	if len(l.input) > 0 {
-		l.pos = len(l.input)
-		// Emitting newline also advances l.line.
-		return l.emit(Newline)
 	}
 	return lexAny
 }

--- a/testdata/scan.ivy
+++ b/testdata/scan.ivy
@@ -109,3 +109,17 @@
 θ = (0 - 7) + ΔJ*(1+ΔJ*(2))
 θ
 	29
+
+op f x = x+1 # comment
+f 1
+	2
+
+op f x =
+ x = x+1 # increment
+ # comment here
+# comment here
+ x = x-1# decrement
+ x
+
+f 1
+	1


### PR DESCRIPTION
Comments in function definitions were disallowed,
even end-of-line comments. I assume this was a bug.

This PR is stacked on others that must be merged first.
To see just the changes specific to this PR when reviewing,
in the "Files Changed" tab, click on "Changes from all commits"
and select just the bottom commit in the list.
