### PR TITLE
ivy: remove extra blank line in print

### DIFF
--- a/testdata/unary_int.ivy
+++ b/testdata/unary_int.ivy
@@ -132,3 +132,10 @@ box 3
 
 first 3
 	3
+
+print 1; print 2
+	1
+	2
+	1 2
+
+

--- a/value/unary.go
+++ b/value/unary.go
@@ -123,7 +123,7 @@ var IvyEval func(context Context, s string) Value
 var UnaryOps = make(map[string]UnaryOp)
 
 func printValue(c Context, v Value) Value {
-	fmt.Printf("%s\n\n", v.Sprint(c.Config()))
+	fmt.Fprintln(c.Config().Output(), v.Sprint(c.Config()))
 	return v
 }
 


### PR DESCRIPTION
The blank line kind of matches interactive mode,
but it is annoying in a long list of debug prints.

This seems wrong:

	% {echo 1; echo 2} >x; ivy x
	1
	2
	% {echo print 1; echo print 2} > x; ivy x
	1

	1
	2

	2
	%

After this CL, there are no blank lines in the second output.

Interactively, before:

	% {echo 1; echo 2} | ivy
	1

	2

	% {echo print 1; echo print 2} | ivy
	1

	1

	2

	2

	%

After:

	% {echo print 1; echo print 2} | ivy
	1
	1

	2
	2

	%

Fixes #177.