### PR TITLE
ivy: allow vector assignment to declare locals in function

### DIFF
--- a/parse/function.go
+++ b/parse/function.go
@@ -238,7 +238,7 @@ func walk(expr value.Expr, assign bool, f func(value.Expr, bool)) {
 	case *variableExpr:
 	case sliceExpr:
 		for i := len(e) - 1; i >= 0; i-- {
-			walk(e[i], false, f)
+			walk(e[i], assign, f)
 		}
 	case value.Char:
 	case value.Int:

--- a/testdata/function.ivy
+++ b/testdata/function.ivy
@@ -39,6 +39,22 @@ op double u = x = x + u; x*2
 double 3; x
 	206 103
 
+# Vector assignments can be locals.
+x y = 10 20
+op f v = x y = v; x+y
+f 1 2
+x y
+	3
+	10 20
+
+# Vector reads can trigger globals.
+x y = 10 20
+op f v = x y; x y = v; x+y
+f 1 2
+x y
+	3
+	1 2
+
 # in g calling f, f used to assign to global y but read from g's y.
 op f x = y = 99; y
 op g y = f y


### PR DESCRIPTION
Consider:

	op f v = x = v; x
	op f v = x y = v; x + y

In the first, x is a local variable.
In the second, x and y should be locals as well,
but not handling vector assignment correctly
meant that they were globals instead.
Fix that.

Fixes #176.