### PR TITLE
ivy: fix print/save of ops with vector arguments

### DIFF
--- a/exec/function.go
+++ b/exec/function.go
@@ -21,12 +21,19 @@ type Function struct {
 	Globals  []string
 }
 
+func argString(v value.Expr) string {
+	if _, ok := v.(value.VectorExpr); ok {
+		return "(" + v.ProgString() + ")"
+	}
+	return v.ProgString()
+}
+
 func (fn *Function) String() string {
 	left := ""
 	if fn.IsBinary {
-		left = fn.Left.ProgString() + " "
+		left = argString(fn.Left) + " "
 	}
-	s := fmt.Sprintf("op %s%s %s =", left, fn.Name, fn.Right.ProgString())
+	s := fmt.Sprintf("op %s%s %s =", left, fn.Name, argString(fn.Right))
 	if len(fn.Body) == 1 {
 		return s + " " + fn.Body[0].ProgString()
 	}

--- a/value/expr.go
+++ b/value/expr.go
@@ -220,7 +220,7 @@ func IsCompound(x interface{}) bool {
 	switch x := x.(type) {
 	case Char, Int, BigInt, BigRat, BigFloat, Complex, *Vector, *Matrix:
 		return false
-	case VectorExpr, *VarExpr:
+	case *VarExpr:
 		return false
 	case *IndexExpr:
 		return IsCompound(x.Left)


### PR DESCRIPTION
save and print were not wrapping vectors arguments in parens, resulting in save and display of invalid syntax.

This does seem to be covered by any tests, I'm happy to add one if desired.