### PR TITLE
README.md: bump to go1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ Slides for a talk at: https://talks.godoc.org/github.com/robpike/ivy/talks/ivy.s
 Video for the talk at: https://www.youtube.com/watch?v=PXoG0WX0r_E
 The talk predates a lot of the features, including floating point, text, and user-defined operators.
 
-To be built, ivy requires Go 1.21.
+To be built, ivy requires Go 1.23.
 
 ![Ivy](ivy.jpg)


### PR DESCRIPTION
hi!

documents that go1.23 is required as of 4ed4c3ebb53371cf22c623ad80bd9f93536b8e62