### PR TITLE
ivy: make vector data immutable, copy-on-write

### DIFF
--- a/order_test.go
+++ b/order_test.go
@@ -67,7 +67,7 @@ func newMatrixData(data ...int) *value.Vector {
 	for i := range data {
 		v[i] = value.Int(data[i])
 	}
-	return value.NewVector(v)
+	return value.NewVector(v...)
 }
 
 func TestOrderedCompare(t *testing.T) {

--- a/parse/function.go
+++ b/parse/function.go
@@ -159,7 +159,7 @@ func (p *Parser) functionDefn() {
 func (p *Parser) funcArg() value.Expr {
 	tok := p.next()
 	if tok.Type == scan.Identifier {
-		return value.NewVar(tok.Text)
+		return value.NewVarExpr(tok.Text)
 	}
 	if tok.Type != scan.LeftParen {
 		p.errorf("invalid function argument syntax at %s", tok.Text)

--- a/parse/save.go
+++ b/parse/save.go
@@ -118,7 +118,7 @@ func save(c *exec.Context, file string) {
 		sorted := sortSyms(syms)
 		for _, sym := range sorted {
 			fmt.Fprintf(out, "%s = ", sym.name)
-			put(conf, out, sym.val, false)
+			put(conf, out, sym.val.Value(), false)
 			fmt.Fprint(out, "\n")
 		}
 	}
@@ -134,7 +134,7 @@ func save(c *exec.Context, file string) {
 // saveSym holds a variable's name and value so we can sort them for saving.
 type saveSym struct {
 	name string
-	val  value.Value
+	val  *value.Var
 }
 
 type sortingSyms []saveSym
@@ -143,7 +143,7 @@ func (s sortingSyms) Len() int           { return len(s) }
 func (s sortingSyms) Less(i, j int) bool { return s[i].name < s[j].name }
 func (s sortingSyms) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
-func sortSyms(syms map[string]value.Value) []saveSym {
+func sortSyms(syms map[string]*value.Var) []saveSym {
 	s := make(sortingSyms, len(syms))
 	i := 0
 	for k, v := range syms {

--- a/parse/special.go
+++ b/parse/special.go
@@ -357,10 +357,10 @@ Switch:
 		name := p.need(scan.Identifier).Text
 		value := p.context.Global(name)
 		if value == nil {
-			p.errorf("%q not defined", name)
+			p.errorf("undefined global variable %q", name)
 		}
 		fmt.Printf("%s = ", name)
-		put(conf, conf.Output(), value, false)
+		put(conf, conf.Output(), value.Value(), false)
 		fmt.Print("\n")
 	default:
 		p.errorf(")%s: not recognized", text)

--- a/testdata/copy.ivy
+++ b/testdata/copy.ivy
@@ -1,0 +1,7 @@
+# testing copy on write
+
+m = 1000 1000 rho 1
+op m step2 n = n==0: m; m step2 n-1
+op m step1 n = n==0: m; (m step2 100) step1 n-1
+rho m step1 100
+	1000 1000

--- a/value/assign.go
+++ b/value/assign.go
@@ -19,25 +19,34 @@ var scalarShape = []int{1} // The assignment shape vector for a scalar
 func assign(context Context, b *BinaryExpr) Value {
 	rhs := b.Right.Eval(context).Inner()
 	Assign(context, b.Left, b.Right, rhs)
-	return QuietValue{Value: rhs.Copy()}
+	return QuietValue{Value: rhs}
 }
 
 func Assign(context Context, left, right Expr, rhs Value) {
 	// We know the left is a variableExpr or index expression.
-	// Special handling as we must not evaluate the left - it is an l-
+	// Special handling as we must not evaluate the left - it is an l-value.
 	// But we need to process the indexing, if it is an index expression.
 	switch lhs := left.(type) {
 	case *VarExpr:
 		if lhs.Local >= 1 {
-			context.AssignLocal(lhs.Local, rhs)
+			context.Local(lhs.Local).Assign(rhs)
 		} else {
 			context.AssignGlobal(lhs.Name, rhs)
 		}
 		return
 	case *IndexExpr:
-		switch lhs.Left.(type) {
+		switch lv := lhs.Left.(type) {
 		case *VarExpr:
-			IndexAssign(context, lhs, lhs.Left, lhs.Right, right, rhs)
+			var v *Var
+			if lv.Local >= 1 {
+				v = context.Local(lv.Local)
+			} else {
+				v = context.Global(lv.Name)
+				if v == nil {
+					Errorf("undefined global variable %q", lv.Name)
+				}
+			}
+			IndexAssign(context, lhs, lhs.Left, v, lhs.Right, right, rhs)
 			return
 		}
 	case VectorExpr:

--- a/value/bigfloat.go
+++ b/value/bigfloat.go
@@ -144,12 +144,6 @@ func (f BigFloat) Eval(Context) Value {
 	return f
 }
 
-func (f BigFloat) Copy() Value {
-	var x big.Float
-	x.Set(f.Float)
-	return BigFloat{&x}
-}
-
 func (f BigFloat) Inner() Value {
 	return f
 }
@@ -163,7 +157,7 @@ func (f BigFloat) toType(op string, conf *config.Config, which valueType) Value 
 	case vectorType:
 		return oneElemVector(f)
 	case matrixType:
-		return NewMatrix([]int{1}, NewVector([]Value{f}))
+		return NewMatrix([]int{1}, NewVector(f))
 	}
 	Errorf("%s: cannot convert float to %s", op, which)
 	return nil

--- a/value/bigint.go
+++ b/value/bigint.go
@@ -144,12 +144,6 @@ func (i BigInt) Eval(Context) Value {
 	return i
 }
 
-func (i BigInt) Copy() Value {
-	var x big.Int
-	x.Set(i.Int)
-	return BigInt{&x}
-}
-
 func (i BigInt) Inner() Value {
 	return i
 }
@@ -169,7 +163,7 @@ func (i BigInt) toType(op string, conf *config.Config, which valueType) Value {
 	case vectorType:
 		return oneElemVector(i)
 	case matrixType:
-		return NewMatrix([]int{1}, NewVector([]Value{i}))
+		return NewMatrix([]int{1}, NewVector(i))
 	}
 	Errorf("%s: cannot convert big int to %s", op, which)
 	return nil

--- a/value/bigrat.go
+++ b/value/bigrat.go
@@ -177,12 +177,6 @@ func (r BigRat) Eval(Context) Value {
 	return r
 }
 
-func (r BigRat) Copy() Value {
-	var x big.Rat
-	x.Set(r.Rat)
-	return BigRat{&x}
-}
-
 func (r BigRat) Inner() Value {
 	return r
 }
@@ -199,7 +193,7 @@ func (r BigRat) toType(op string, conf *config.Config, which valueType) Value {
 	case vectorType:
 		return oneElemVector(r)
 	case matrixType:
-		return NewMatrix([]int{1, 1}, NewVector([]Value{r}))
+		return NewMatrix([]int{1, 1}, NewVector(r))
 	}
 	Errorf("%s: cannot convert rational to %s", op, which)
 	return nil

--- a/value/char.go
+++ b/value/char.go
@@ -40,10 +40,6 @@ func (c Char) Eval(Context) Value {
 	return c
 }
 
-func (c Char) Copy() Value {
-	return c
-}
-
 func (c Char) Inner() Value {
 	return c
 }
@@ -55,7 +51,7 @@ func (c Char) toType(op string, conf *config.Config, which valueType) Value {
 	case vectorType:
 		return oneElemVector(c)
 	case matrixType:
-		return NewMatrix([]int{1}, NewVector([]Value{c}))
+		return NewMatrix([]int{1}, NewVector(c))
 	}
 	Errorf("%s: cannot convert char to %s", op, which)
 	return nil

--- a/value/complex.go
+++ b/value/complex.go
@@ -54,13 +54,6 @@ func (c Complex) Eval(Context) Value {
 	return c
 }
 
-func (c Complex) Copy() Value {
-	return Complex{
-		real: c.real.Copy(),
-		imag: c.real.Copy(),
-	}
-}
-
 func (c Complex) Inner() Value {
 	return c
 }
@@ -83,7 +76,7 @@ func (c Complex) toType(op string, conf *config.Config, which valueType) Value {
 	case vectorType:
 		return oneElemVector(c)
 	case matrixType:
-		return NewMatrix([]int{1, 1}, NewVector([]Value{c}))
+		return NewMatrix([]int{1, 1}, NewVector(c))
 	}
 	Errorf("%s: cannot convert complex to %s", op, which)
 	return nil

--- a/value/const.go
+++ b/value/const.go
@@ -36,7 +36,7 @@ var (
 )
 
 var (
-	empty = NewVector([]Value{})
+	empty = NewVector()
 
 	bigIntZero     = bigInt64(0)
 	bigIntOne      = bigInt64(1)

--- a/value/context.go
+++ b/value/context.go
@@ -4,7 +4,11 @@
 
 package value
 
-import "robpike.io/ivy/config"
+import (
+	"fmt"
+
+	"robpike.io/ivy/config"
+)
 
 // Decomposable allows one to pull apart a parsed expression.
 // Only implemented by Expr types that need to be decomposed
@@ -29,6 +33,63 @@ type BinaryOp interface {
 	EvalBinary(c Context, right, left Value) Value
 }
 
+// A Var is a named variable in an Ivy execution.
+type Var struct {
+	name  string
+	value Value
+	edit  *vectorEditor
+}
+
+// Name returns v's name.
+func (v *Var) Name() string {
+	return v.name
+}
+
+// Value returns v's current value.
+func (v *Var) Value() Value {
+	if v.edit != nil {
+		// Flush edits back into v.value.
+		edit := v.edit
+		v.edit = nil
+		switch val := v.value.(type) {
+		default:
+			panic(fmt.Sprintf("internal error: misuse of transient for var %s of type %T", v.name, v.value))
+		case *Vector:
+			v.value = edit.Publish()
+		case *Matrix:
+			v.value = &Matrix{shape: val.shape, data: edit.Publish()}
+		}
+	}
+	return v.value
+}
+
+// Assign assigns value to v.
+func (v *Var) Assign(value Value) {
+	v.value = value
+	v.edit = nil
+}
+
+// editor returns a vectorEditor for editing v's underlying data
+// (supporting an indexed assignment like v[i] = x).
+func (v *Var) editor() *vectorEditor {
+	if v.edit == nil {
+		switch val := v.value.(type) {
+		default:
+			panic(fmt.Sprintf("internal error: misuse of transient for var %s of type %T", v.name, v.value))
+		case *Vector:
+			v.edit = val.edit()
+		case *Matrix:
+			v.edit = val.data.edit()
+		}
+	}
+	return v.edit
+}
+
+// NewVar returns a new Var with the given name and value.
+func NewVar(name string, value Value) *Var {
+	return &Var{name: name, value: value}
+}
+
 // Context is the execution context for evaluation.
 // The only implementation is ../exec/Context, but the interface
 // is defined separately, here, because of the dependence on Expr
@@ -37,16 +98,15 @@ type Context interface {
 	// Config returns the configuration state for evaluation.
 	Config() *config.Config
 
-	// Local returns the value of the i'th local variable.
-	Local(i int) Value
+	// Local returns the i'th local variable.
+	Local(i int) *Var
 
-	// AssignLocal assigns to the i'th local variable.
-	AssignLocal(i int, value Value)
+	// Global returns the named global variable.
+	// It returns nil if there is no such variable.
+	Global(name string) *Var
 
-	// Global returns the value of the named global variable.
-	Global(name string) Value
-
-	// AssignGlobal assigns to the named global variable.
+	// AssignGlobal assigns to the named global variable,
+	// creating it if needed.
 	AssignGlobal(name string, value Value)
 
 	// Eval evaluates a list of expressions.

--- a/value/format.go
+++ b/value/format.go
@@ -11,7 +11,6 @@ import (
 	"math/big"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"robpike.io/ivy/config"
 )
@@ -56,12 +55,7 @@ func fmtText(c Context, u, v Value) Value {
 	default:
 		Errorf("cannot format '%s'", val.Sprint(config))
 	}
-	str := b.String()
-	elem := make([]Value, utf8.RuneCountInString(str))
-	for i, r := range str {
-		elem[i] = Char(r)
-	}
-	return NewVector(elem)
+	return newCharVector(b.String())
 }
 
 // formatString returns the format string given u, the lhs of a binary text invocation.

--- a/value/int.go
+++ b/value/int.go
@@ -148,10 +148,6 @@ func (i Int) Eval(Context) Value {
 	return i
 }
 
-func (i Int) Copy() Value {
-	return i
-}
-
 func (i Int) Inner() Value {
 	return i
 }
@@ -171,7 +167,7 @@ func (i Int) toType(op string, conf *config.Config, which valueType) Value {
 	case vectorType:
 		return oneElemVector(i)
 	case matrixType:
-		return NewMatrix([]int{1}, NewVector([]Value{i}))
+		return NewMatrix([]int{1}, NewVector(i))
 	}
 	Errorf("%s: cannot convert int to %s", op, which)
 	return nil

--- a/value/value.go
+++ b/value/value.go
@@ -24,9 +24,6 @@ type Value interface {
 	// Eval evaluates (simplifies) the Value.
 	Eval(Context) Value
 
-	// Copy returns a copy of the Value.
-	Copy() Value
-
 	// Inner retrieves the value, without evaluation. But for Assignments,
 	// it returns the right-hand side.
 	Inner() Value


### PR DESCRIPTION
This "benchmark" does 10,000 function calls passing an ignored 1000x1000 matrix as an argument.
The old implementation made a copy every time a value was assigned to a variable, making the parameter passing very expensive. The implementation in this CL makes a copy each time modified data is copied out of a variable, eliminating all the copies when the data has not changed (and eliminating the Value.Copy method).

% time ivy0.3.11 testdata/copy.ivy
1000 1000
1000 1000
       58.22 real        93.94 user        42.62 sys
% time ivy testdata/copy.ivy
1000 1000
1000 1000
        0.27 real         0.04 user         0.01 sys
%

A follow-up change may replace the underlying storage with a more fine-grained copy-on-write tree data structure, but this is already a huge improvement, and it sets up for alternate representations in the Vector and vectorEditor types. Changing the underlying data structure will now only require changing the Vector and vectorEditor implementations.