### PR TITLE
ivy: fix declaration of binary ops

### DIFF
--- a/parse/function.go
+++ b/parse/function.go
@@ -52,6 +52,9 @@ func (p *Parser) functionDefn(start int) {
 		if x.Name == fn.Name {
 			p.errorf("argument name %q is function name", fn.Name)
 		}
+		if x.Name == "_" {
+			return
+		}
 		if argNames[x.Name] {
 			p.errorf("multiple arguments named %q", x.Name)
 		}

--- a/testdata/save.ivy
+++ b/testdata/save.ivy
@@ -95,12 +95,39 @@ op m1 n = n
 	e = 2.71828182845904523536028747135266249775724709369995957496696762772407663035355
 	pi = 3.1415926535897932384626433832795028841971693993751058209749445923078164062862
 
+# Recursive binary operators
+op x gcd y =
+  not x*y: x+y
+  x > y: (x mod y) gcd y
+  x <= y: x gcd (y mod x)
+
+)save "<conf.out>"
+	)ibase 0
+	)prec 256
+	)maxbits 1000000000
+	)maxdigits 10000
+	)origin 1
+	)prompt ""
+	)format ""
+	)obase 0
+	op _ gcd _
+	op x gcd y =
+	  not x*y: x+y
+	  x > y: (x mod y) gcd y
+	  x <= y: x gcd (y mod x)
+
+
+	e = 2.71828182845904523536028747135266249775724709369995957496696762772407663035355
+	pi = 3.1415926535897932384626433832795028841971693993751058209749445923078164062862
+
 # Test that we can see variables and ops created by reading from a file.
 )get "testdata/saved"
 x
 avg x
+12 gcd 15
 	1 2 3 4 5 6 7
 	4
+	3
 
 # Indexing operations
 op g x = x

--- a/testdata/saved
+++ b/testdata/saved
@@ -1,2 +1,8 @@
 x = iota 7
+op _ gcd _
+op x gcd y =
+	not x*y: x+y
+	x > y: (x mod y) gcd y
+	x <= y: x gcd (y mod x)
+
 op avg n = (+/n)/rho n


### PR DESCRIPTION
)save prints these declarations
but )get wasn't parsing them.
I broke this introducing named vector arguments.